### PR TITLE
EUW-596  Documents are sharable multiple times through use of rotateUse policy 

### DIFF
--- a/Modules/logic-core/Sources/Config/WalletKitConfig.swift
+++ b/Modules/logic-core/Sources/Config/WalletKitConfig.swift
@@ -197,11 +197,11 @@ struct WalletKitConfigImpl: WalletKitConfig {
       ),
       documentSpecificRules: [
         DocumentTypeIdentifier.mDocPid: DocumentIssuanceRule(
-          policy: .oneTimeUse,
+          policy: .rotateUse,
           numberOfCredentials: 10
         ),
         DocumentTypeIdentifier.sdJwtPid: DocumentIssuanceRule(
-          policy: .oneTimeUse,
+          policy: .rotateUse,
           numberOfCredentials: 10
         )
       ]


### PR DESCRIPTION
## Ticket
[EUW-596](https://digdir.atlassian.net/jira/software/c/projects/EUW/boards/119?selectedIssue=EUW-596)

## Type of change
Changed the document issuance policy from **oneTimeUse** to **rotateUse** to enable the sharing of the same document multiple times like before. 

The latest EU implementations set the default policy as **oneTimeUse** for mDocs, which is not what we wanted. This made the available documents appear as 0/1 when they were shared once. They still existed on the phone, but were used up and had to be renewed. With the **rotateUse** policy a sharable instance of the document is always available and not deleted after you share the document once with a verifier.

In the video. The two upper proofs/documents used the **oneTimeUse** policy, while the one furthest down uses the **rotateUse** policy.

### Types of fix
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
I've tested it by running the code after implementing the changes.
- [x] Test suite run successfully


## Screenshot video

https://github.com/user-attachments/assets/3835a2f6-08ed-4b42-a7be-670a4c711bee




[EUW-596]: https://digdir.atlassian.net/browse/EUW-596?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ