### PR TITLE
EUW-575 New Issuer URL

### DIFF
--- a/Modules/logic-core/Sources/Config/WalletKitConfig.swift
+++ b/Modules/logic-core/Sources/Config/WalletKitConfig.swift
@@ -98,7 +98,7 @@ struct WalletKitConfigImpl: WalletKitConfig {
     return switch configLogic.appBuildVariant {
     case .DEMO:
         .init(
-          issuerUrl: "https://issuer.eudiw.dev",
+          issuerUrl: "https://utsteder.test.eidas2sandkasse.net",
           clientId: "wallet-dev",
           redirectUri: URL(string: "eu.europa.ec.euidi://authorization")!,
           usePAR: true,
@@ -106,7 +106,7 @@ struct WalletKitConfigImpl: WalletKitConfig {
         )
     case .DEV:
         .init(
-          issuerUrl: "https://demo-utsteder.test.eidas2sandkasse.net",
+          issuerUrl: "https://utsteder.test.eidas2sandkasse.net",
           clientId: "demo-lommebok",
           redirectUri: URL(string: "eu.europa.ec.euidi://authorization")!,
           usePAR: true,


### PR DESCRIPTION
### Ticket
[EUW-575](https://digdir.atlassian.net/jira/software/c/projects/EUW/boards/119?assignee=557058%3A272fa8f8-e3df-431d-be72-24e6a04d7a9d&assignee=712020%3Ad3896c86-802a-4e89-afd8-13aac8f5ec02&assignee=712020%3A975aee4c-17a8-4284-b59f-101347140b2b&assignee=712020%3A8d7f179c-036e-4fb5-a7ea-3ac6a6ef0399&selectedIssue=EUW-575)

### Type of change
Changed the url of the issuer.
I changed both the Dev and Demo configuration to use the new issuer. 

We can add the old issuer url any time if we want it and if it is needed -> https://demo-utsteder.test.eidas2sandkasse.net

### How Has This Been Tested?
Tested the usual verification and issuance flow. At this point, that is Issuance of pid and verification of birth/D-number. 
Verification is done towards: https://demo-brukersted.eidas2sandkasse.dev

## Checklist:

- [x] I have performed a self-review of my own code


[EUW-575]: https://digdir.atlassian.net/browse/EUW-575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ